### PR TITLE
Change point typedef to include RGB channels

### DIFF
--- a/include/point_cloud2_filters/FilterBasePointCloud2.hpp
+++ b/include/point_cloud2_filters/FilterBasePointCloud2.hpp
@@ -23,7 +23,7 @@
 
 namespace point_cloud2_filters {
     
-typedef pcl::PointXYZ Point;
+typedef pcl::PointXYZRGB Point;
 typedef pcl::PointCloud<Point> PointCloud;
 
 class FilterBasePointCloud2 : public filters::FilterBase<sensor_msgs::PointCloud2>


### PR DESCRIPTION
Hello,

Great tools! They are super helpful. Only thing that bothered me was that the filters remove the color information of the pointcloud. 

I tested giving a XYZ Pointcloud as input after the change and it seems to work fine with no issue, so this change should not break any existing implementations. Would be great if someone could verify that though :P